### PR TITLE
Remove dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: gomod
-    directory: /
-    schedule:
-      interval: daily


### PR DESCRIPTION
I noticed my script missed that this repo has `dependabot.yaml` (it was looking for `dependabot.yml`).

It looks like the dependabot configuration was only updating go modules, so maybe better to go forward with renovate?