### PR TITLE
Upload coverage report to codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,12 @@ jobs:
         with:
           check-latest: true
           go-version: ${{ matrix.go-version }}
-      - run: go test -v ./...
+      - run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+      - uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        with:
+          fail_ci_if_error: true
+          files: ./coverage.txt
+          verbose: true
   golangci:
     name: lint
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+.DS_Store
+Thumbs.db
+
+.cache/
+.tools/
+venv/
+.idea/
+.vscode/
+*.iml
+*.so
+coverage.*
+go.work
+go.work.sum


### PR DESCRIPTION
Also, add a boilerplate `.gitignore` that includes exclusion of coverage reports.